### PR TITLE
superficial code cleanup (pep8 formatting style)

### DIFF
--- a/hypigu/src/Braid.py
+++ b/hypigu/src/Braid.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2020 Joshua Maglione 
+#   Copyright 2020 Joshua Maglione
 #
 #   Distributed under MIT License
 #
@@ -9,6 +9,7 @@ from sage.all import factorial as _factorial
 from functools import reduce as _reduce
 
 _TABLE_CUTOFF = 3
+
 
 def _Igusa_braid_table(p, t, n, style="standard"):
     if n <= 0:
@@ -20,14 +21,14 @@ def _Igusa_braid_table(p, t, n, style="standard"):
             return (1 + p)/(1 - t)
         else:
             return (1 - p**-1)/(1 - p**-1*t)
-    if n == 2: 
+    if n == 2:
         if style == "reduced":
             return (6 + 6*t)/((1 - t)*(1 - t**3))
         elif style == "skeleton":
             return ((1 + 3*p + 2*p**2) + (2 + 3*p + p**2)*t)/((1 - t)**2)
         else:
             return (1-p**-1)*(1-2*p**-1+2*p**-1*t-p**-2*t)/((1-p**-1*t)*(1-p**-2*t**3))
-    if n == 3: 
+    if n == 3:
         if style == "reduced":
             return (24 + 48*t + 24*t**2 + 48*t**3 + 24*t**4)/((1 - t)*(1 - t**3)*(1 - t**6))
         elif style == "skeleton":
@@ -36,12 +37,14 @@ def _Igusa_braid_table(p, t, n, style="standard"):
             return p**-6*(1-p**-1)*(p**4*(6-5*p+p**2)-4*p**4*(2-p)*t-p**2*(3-7*p+2*p**2)*t**2+p**2*(2-7*p+3*p**2)*t**3-4*p*(1-2*p)*t**4-(1-5*p+6*p**2)*t**5)/((1-p**-1*t)**2*(1-p**-2*t**3)*(1-p**-3*t**6))
     raise ValueError("Bad n-value.")
 
+
 # Counts the number of set partitions of [L[0] + ... + L[-1]]. So instead of
 # running through all *labeled* partitions, we just run through the partition
 # "shape" and count the number of different labelings.
 def _P(L):
     from sage.all import Set
     # Compute binom(n, p_1)*binom(n - p_1, p_2)*binom(n - p_1 - p_2, p_3)*...
+
     def binom(n, P):
         if len(P) == 1:
             return _binomial(n, P[0])
@@ -53,25 +56,28 @@ def _P(L):
     d = _reduce(lambda x, y: x*y, map(lambda z: _factorial(count(z)), S))
     return binom(n, L) // d
 
+
 # Counts the number of edges in a subgraph of the complete graph determined by L
 def _binom_sum(L):
     binomials = map(lambda z: _binomial(z, 2), L)
     return _reduce(lambda x, y: x + y, binomials)
 
+
 # Constructs the Poincare polynomial (in Y) of the braid arrangement in |L|-1
 # affine space.
-def _Poincare(L): 
+def _Poincare(L):
     from sage.all import var
     Y = var('Y')
     factors= map(lambda z: 1 + z*Y, range(1, len(L)))
     return _reduce(lambda x, y: x*y, factors, 1)
 
+
 # Constructs the Igusa integral for the braid arrangement with little repetition
-# of work. 
+# of work.
 def _recursive_crank(p, t, n, known=[], style="standard"):
-    from sage.all import Partitions 
+    from sage.all import Partitions
     if known == []:
-        known = [_Igusa_braid_table(p, t, k, style=style) 
+        known = [_Igusa_braid_table(p, t, k, style=style)
             for k in range(_TABLE_CUTOFF + 1)]
     k = len(known) + 1
     Zk = 0
@@ -81,7 +87,7 @@ def _recursive_crank(p, t, n, known=[], style="standard"):
                 L_factors = [_P(L), 1, t**(_binom_sum(L)), _factorial(len(L))]
             else:
                 L_factors = [
-                    _P(L), p**(1-_reduce(lambda x, y: x + y - 1, L)), 
+                    _P(L), p**(1-_reduce(lambda x, y: x + y - 1, L)),
                     t**(_binom_sum(L)), _Poincare(L)(Y=-p**-1)
                 ]
             lower_integrals = list(map(lambda z: known[z - 1], list(L)))
@@ -96,6 +102,7 @@ def _recursive_crank(p, t, n, known=[], style="standard"):
         return _recursive_crank(p, t, n, known=known, style=style)
     else:
         return known[n]
+
 
 def BraidArrangementIgusa(n):
     r"""
@@ -123,4 +130,3 @@ def BraidArrangementIgusa(n):
     if n <= _TABLE_CUTOFF:
         return _Igusa_braid_table(p, t, n, style="standard")
     return _recursive_crank(p, t, n, style="standard")
-

--- a/hypigu/src/Constructors.py
+++ b/hypigu/src/Constructors.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2020 Joshua Maglione 
+#   Copyright 2020 Joshua Maglione
 #
 #   Distributed under MIT License
 #
@@ -7,28 +7,30 @@
 def _non_Weyl_arrangements(X, n, shift=[0]):
     from functools import reduce
     from sage.all import HyperplaneArrangements, QQ, CoxeterGroup
+
     def add_shift(x):
         return list(map(lambda k: [k] + list(x), shift))
     if X == 'I':
         # Not expecting n <= 2 for type I.
         if n == 3:
             return _arrangements_from_roots("A", 2, shift=shift)
-        if n == 4: 
+        if n == 4:
             return _arrangements_from_roots("B", 2, shift=shift)
         H = HyperplaneArrangements(QQ, tuple(['x0', 'x1']))
         norms = [tuple([1, 0]), tuple([0, 1]), tuple([1, 1]), tuple([1, -1])]
         cval = 2
         for k in range(n - 4):
-            norms.append(tuple([(-1)**(k%2), cval + (k // 2)]))
+            norms.append(tuple([(-1)**(k % 2), cval + (k // 2)]))
     else:
         if n == 2:
             return _non_Weyl_arrangements("I", 5, shift=shift)
         W = CoxeterGroup([X, n])
         H = HyperplaneArrangements(W.base_ring(), tuple(['x' + str(k) for k in range(n)]))
         norms = W.positive_roots()
-    aff_norms = reduce(lambda x, y: x+y, map(lambda x: add_shift(x), norms),[])
+    aff_norms = reduce(lambda x, y: x+y, map(lambda x: add_shift(x), norms), [])
     return H(aff_norms)
-    
+
+
 def _arrangements_from_roots(X, n, shift=[0]):
     from functools import reduce
     from sage.all import HyperplaneArrangements, QQ, RootSystem
@@ -36,22 +38,24 @@ def _arrangements_from_roots(X, n, shift=[0]):
     d = Phi.dimension()
     H = HyperplaneArrangements(QQ, tuple(['x' + str(i) for i in range(d)]))
     norms = Phi.positive_roots()
+
     def add_shift(x):
         norm = tuple(map(lambda i: QQ(i), x._vector_().list()))
         return list(map(lambda k: [norm, k], shift))
-    aff_norms = reduce(lambda x, y: x+y, map(lambda x: add_shift(x), norms),[])
+    aff_norms = reduce(lambda x, y: x+y, map(lambda x: add_shift(x), norms), [])
     return H(aff_norms)
+
 
 # Verifies that the Coxeter-theoretic data is expected.
 def _Coxeter_check(X, n):
     if n <= 0:
         raise ValueError("Expected a positive rank.")
-    if not X in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']:
+    if X not in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']:
         raise ValueError(
             "Expected first character to be in {A, B, C, D, E, F, G, H, I}."
         )
     if X in ['E', 'F', 'G', 'H']:
-        if X == 'E' and not n in {6, 7, 8}:
+        if X == 'E' and n not in {6, 7, 8}:
             raise ValueError(
                 "Expected rank to be either 6, 7, or 8."
             )
@@ -63,7 +67,7 @@ def _Coxeter_check(X, n):
             raise ValueError(
                 "Expected rank to be 2."
             )
-        if X == 'H' and not n in {2, 3, 4}:
+        if X == 'H' and n not in {2, 3, 4}:
             raise ValueError(
                 "Expected rank to be either 2, 3, or 4."
             )
@@ -73,15 +77,16 @@ def _Coxeter_check(X, n):
             )
     return True
 
-# Parses the Coxeter type input and runs the check for good input. 
+
+# Parses the Coxeter type input and runs the check for good input.
 def _parse_Coxeter_input(name):
-    from sage.all import ZZ
     if isinstance(name, str):
         factors = name.split(' ')
     else:
         factors = list(name)
-        if not isinstance(factors[0], str): 
+        if not isinstance(factors[0], str):
             raise TypeError("Expected ``name`` to be an interable container of strings.")
+
     def convert(s):
         if len(s) <= 1:
             raise ValueError("Cannot parse input: {0}".format(s))
@@ -93,6 +98,7 @@ def _parse_Coxeter_input(name):
     Cox_facts = list(map(convert, factors))
     assert all(map(lambda X: _Coxeter_check(X[0], X[1]), Cox_facts))
     return Cox_facts
+
 
 # Builds the direct sum arrangement of arrangements A and B.
 def _direct_sum(A, B):
@@ -106,9 +112,10 @@ def _direct_sum(A, B):
     B_emb = map(lambda L: L[0:1] + [0]*(A.dimension()) + L[1:], B_H)
     return HH(list(A_emb) + list(B_emb))
 
+
 def _basic_wrapper(name, s):
-    from functools import reduce
     factors = _parse_Coxeter_input(name)
+
     def irr_facts(X):
         if X[0] in {'I', 'H'}:
             return _non_Weyl_arrangements(X[0], X[1], shift=s)
@@ -118,9 +125,11 @@ def _basic_wrapper(name, s):
     irr_arr = list(map(irr_facts, factors))
     return DirectSum(irr_arr)
 
+
 def _res_arr(n):
     from sage.all import Subsets, HyperplaneArrangements, QQ, Matrix
     Subs = Subsets(range(1, n + 1))
+
     def S_vec(S):
         v = [QQ(0)]*(n+1)
         for s in S:
@@ -138,7 +147,7 @@ def DirectSum(*args):
 
     INPUT:
 
-    - An iterable container of hyperplane arrangements. 
+    - An iterable container of hyperplane arrangements.
 
     OUTPUT: the direct sum arrangement given as a hyperplane arrangement.
 
@@ -158,7 +167,7 @@ def DirectSum(*args):
         HPAs = args[0]
     else:
         HPAs = args
-    if len(HPAs) == 1: 
+    if len(HPAs) == 1:
         return HPAs[0]
     else:
         D = _direct_sum(HPAs[0], HPAs[1])
@@ -171,8 +180,8 @@ def CoxeterArrangement(name):
 
     INPUT:
 
-    - ``name`` -- an interable container of strings; the Coxeter group 
-        name. The string must include a letter from {A, ..., H} and a 
+    - ``name`` -- an interable container of strings; the Coxeter group
+        name. The string must include a letter from {A, ..., H} and a
         nonnegative integer.
 
     OUTPUT: the Coxeter arrangement given as a hyperplane arrangement.
@@ -197,8 +206,8 @@ def ShiArrangement(name):
 
     INPUT:
 
-    - ``name`` -- an interable container of strings; the Coxeter group 
-        name. The string must include a letter from {A, ..., H} and a 
+    - ``name`` -- an interable container of strings; the Coxeter group
+        name. The string must include a letter from {A, ..., H} and a
         nonnegative integer.
 
     OUTPUT: the Shi arrangement given as a hyperplane arrangement.
@@ -223,8 +232,8 @@ def LinialArrangement(name):
 
     INPUT:
 
-    - ``name`` -- an interable container of strings; the Coxeter group 
-        name. The string must include a letter from {A, ..., H} and a 
+    - ``name`` -- an interable container of strings; the Coxeter group
+        name. The string must include a letter from {A, ..., H} and a
         nonnegative integer.
 
     OUTPUT: the Linial arrangement given as a hyperplane arrangement.
@@ -249,8 +258,8 @@ def CatalanArrangement(name):
 
     INPUT:
 
-    - ``name`` -- an interable container of strings; the Coxeter group 
-        name. The string must include a letter from {A, ..., H} and a 
+    - ``name`` -- an interable container of strings; the Coxeter group
+        name. The string must include a letter from {A, ..., H} and a
         nonnegative integer.
 
     OUTPUT: the Catalan arrangement given as a hyperplane arrangement.
@@ -267,6 +276,7 @@ def CatalanArrangement(name):
         Arrangement of 54 hyperplanes of dimension 8 and rank 7
     """
     return _basic_wrapper(name, [-1, 0, 1])
+
 
 def ResonanceArrangement(n):
     r"""
@@ -291,10 +301,11 @@ def ResonanceArrangement(n):
     """
     return _res_arr(n)
 
+
 def PolynomialToArrangement(f):
     r"""
-    Return the associated hyperplane arrangement of f, the given product of 
-    linear polynomials. 
+    Return the associated hyperplane arrangement of f, the given product of
+    linear polynomials.
 
     INPUT:
 
@@ -315,6 +326,5 @@ def PolynomialToArrangement(f):
         Arrangement of 7 hyperplanes of dimension 4 and rank 4
     """
     from .GenFunctions import _parse_poly
-    A, M = _parse_poly(f)
+    A, _ = _parse_poly(f)
     return A
-    

--- a/hypigu/src/Database.py
+++ b/hypigu/src/Database.py
@@ -42,14 +42,14 @@ class IADatabase():
         if not isit:
             # New poset, so we save it.
             gen_dict = {
-                'Igusa' : None,
-                'skele' : None
+                'Igusa': None,
+                'skele': None
             }
             gen_dict[style] = F
             self.poset_list += [P]
             self.gen_func_list += [gen_dict]
         else:
-            if self.gen_func_list[k][style] == None:
+            if self.gen_func_list[k][style] is None:
                 GFL = self.gen_func_list
                 GFL[k][style] = F
                 self.gen_func_list = GFL

--- a/hypigu/src/GenFunctions.py
+++ b/hypigu/src/GenFunctions.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2021 Joshua Maglione 
+#   Copyright 2021 Joshua Maglione
 #
 #   Distributed under MIT License
 #
@@ -9,18 +9,21 @@ from .Globals import __PRINT as _print
 from .Globals import __TIME as _time
 from functools import reduce as _reduce
 
+
 # A function to return a poincare function.
 def _Poincare_polynomial(L, sub=None):
-    from sage.all import var 
-    if sub == None:
+    from sage.all import var
+    if sub is None:
         sub = var('Y')
+
     def poincare(x):
         pi = L.restriction(x).Poincare_polynomial()
         try:
-            return pi.subs({pi.variables()[0] : sub})
-        except AttributeError: # In case pi is a constant.
+            return pi.subs({pi.variables()[0]: sub})
+        except AttributeError:  # In case pi is a constant.
             return pi
     return poincare
+
 
 # The complete solutions for small central arrangements of rank <= 2.
 def _small_central(A, style, numerator=False):
@@ -35,7 +38,7 @@ def _small_central(A, style, numerator=False):
             return (1 - p**-1)/(1 - p**-1*t)
         if style == 'skele':
             if numerator:
-                return 1 + Y 
+                return 1 + Y
             else:
                 return (1 + Y)/(1 - T)
     # Now we assume the rank == 2.
@@ -47,6 +50,7 @@ def _small_central(A, style, numerator=False):
             return 1 + m*Y + (m-1)*Y**2 + (m-1 + m*Y + Y**2)*T
         else:
             return (1 + m*Y + (m-1)*Y**2 + (m-1 + m*Y + Y**2)*T)/((1 - T)**2)
+
 
 # The direct version of the universal generating function computation.
 def _universal(L, anayltic=False, atom=False):
@@ -61,6 +65,7 @@ def _universal(L, anayltic=False, atom=False):
         t_name = lambda x: var("t" + str(x))
         if atom:
             atoms = P.upper_covers(P.bottom())
+
             def T_data(x):
                 under_poset = _subposet(P, x, lambda z: P.lower_covers(z))
                 elts = filter(lambda y: y in under_poset, atoms)
@@ -73,12 +78,12 @@ def _universal(L, anayltic=False, atom=False):
                 elts.remove(P.bottom())
                 ts = map(t_name, elts)
                 return _reduce(lambda x, y: x*y, ts, q**(-P.rank(x)))
-    else: 
+    else:
         T_data = lambda x: var("T" + str(x))
         Y = var('Y')
 
-    T = {x : T_data(x) for x in L.poset._elements}
-    
+    T = {x: T_data(x) for x in L.poset._elements}
+
     # Base cases for recursion.
     if L.poset.has_top() and L.poset.rank() == 2:
         elts = L.proper_part_poset()._elements
@@ -89,7 +94,7 @@ def _universal(L, anayltic=False, atom=False):
         elts = list(L.poset._elements).remove(L.poset.bottom())
         merge = lambda x, y: x + (1 + Y)*T[y]/(1 - T[y])
         return _reduce(merge, elts, 1 + len(elts)*Y)
-    
+
     P = L.proper_part_poset()
     poincare = _Poincare_polynomial(L, sub=Y)
     recurse = lambda M: _universal(M, anayltic=anayltic, atom=atom)
@@ -99,6 +104,7 @@ def _universal(L, anayltic=False, atom=False):
     if L.poset.has_top():
         HP = HP/(1 - T[L.poset.top()])
     return HP
+
 
 def _Igusa_zeta_function(L, DB=True, verbose=_print):
     from sage.all import var
@@ -120,9 +126,9 @@ def _Igusa_zeta_function(L, DB=True, verbose=_print):
 
     if DB:
         zeta = _data.get_gen_func(P, 'Igusa')
-        if zeta != None:
+        if zeta is not None:
             return zeta
-    # We check to see if we have a type A braid arrangement. 
+    # We check to see if we have a type A braid arrangement.
     # We can compute these *extremely* quickly.
     if _Coxeter_poset_data()['A']['hyperplanes'](P.rank()) == len(L.atoms()):
         if _Coxeter_poset_data()['A']['poset'](P.rank()) == len(P):
@@ -140,7 +146,7 @@ def _Igusa_zeta_function(L, DB=True, verbose=_print):
     zeta = _reduce(lambda x, y: x + y[0]*y[1], zip(factors, integrals), 0) + pi
     if P.has_top():
         zeta = zeta/(1 - q**(-P.rank())*t**len(L.atoms()))
-    if DB and P.rank() > 2: 
+    if DB and P.rank() > 2:
         _data.save_gen_func(P, 'Igusa', zeta)
     return zeta
 
@@ -179,12 +185,13 @@ def _top_zeta_function_mul(L, DB=True, verbose=_print, atom=False):
     from .LatticeFlats import _subposet
 
     P = L.poset
-    C = 1*L.poset.has_top()
+    C = 1 * L.poset.has_top()
 
     s_name = lambda x: var("s" + str(x))
     if atom:
         if atom:
             atoms = P.upper_covers(P.bottom())
+
             def s_data(x):
                 under_poset = _subposet(P, x, lambda z: P.lower_covers(z))
                 elts = filter(lambda y: y in under_poset, atoms)
@@ -198,7 +205,7 @@ def _top_zeta_function_mul(L, DB=True, verbose=_print, atom=False):
             ts = map(s_name, elts)
             return _reduce(lambda x, y: x + y, ts, 0)
 
-    S = {x : s_data(x) for x in P._elements}
+    S = {x: s_data(x) for x in P._elements}
 
     # Base cases for recursion.
     add_em = lambda x, y: x + y
@@ -244,13 +251,13 @@ def _comb_skele(L, DB=True, verbose=_print):
         if verbose:
             print(_time() + "Checking database.")
         zeta = _data.get_gen_func(P, 'skele')
-        if zeta != None:
+        if zeta is not None:
             return zeta
         if verbose:
             print("\tDone.")
 
     poincare = _Poincare_polynomial(L)
-    if verbose: 
+    if verbose:
         print(_time() + "Gleaning structure from poset.")
     eq_elt_data = L._combinatorial_eq_elts()
     if verbose:
@@ -266,25 +273,26 @@ def _comb_skele(L, DB=True, verbose=_print):
     zeta = _reduce(lambda x, y: x + y[0]*y[1], zip(factors, integrals), 0) + pi
     if P.has_top():
         zeta = zeta/(1 - T)
-    if DB and P.rank() > 2: 
+    if DB and P.rank() > 2:
         _data.save_gen_func(P, 'skele', zeta)
-        
+
     return zeta
 
+
 # Given a polynomial, return a hyperplane arrangement equivalent to the linear
-# factors of f. 
-def _parse_poly(f): 
+# factors of f.
+def _parse_poly(f):
     from sage.all import SR, QQ, HyperplaneArrangements, Matrix
     if type(f) == str:
         f = SR(f)
     if f.base_ring() == SR:
         L = f.factor_list()
         K = QQ
-    else: 
+    else:
         L = list(f.factor())
         K = f.base_ring()
 
-    L = filter(lambda T: not T[0] in K, L) # Remove constant factors
+    L = filter(lambda T: not T[0] in K, L)  # Remove constant factors
     F, M = list(zip(*L))
 
     # Verify that each polynomial factor is linear
@@ -297,7 +305,7 @@ def _parse_poly(f):
     HH = HyperplaneArrangements(K, varbs_str)
 
     def poly_vec(g):
-        c = K(g.subs({x : 0 for x in g.variables()}))
+        c = K(g.subs({x: 0 for x in g.variables()}))
         return tuple([c] + [K(g.coefficient(x)) for x in varbs])
 
     F_vec = tuple(map(poly_vec, F))
@@ -311,21 +319,19 @@ def _parse_poly(f):
     return A, M_new
 
 
-
-
 def CoarseFlagHPSeries(A=None, lattice_of_flats=None, int_poset=None, matroid=None, numerator=False, verbose=_print):
     from .LatticeFlats import LatticeOfFlats
 
-    if matroid == None: 
+    if matroid is None:
         try:
             if A.is_central() and A.rank() <= 2:
                 return _small_central(A, 'skele', numerator=numerator)
         except AttributeError:
             raise TypeError("object is not a hyperplane arrangement.")
-    if lattice_of_flats == None:
+    if lattice_of_flats is None:
         if verbose:
             print("{0}Building lattice of flats".format(_time()))
-        if matroid == None:
+        if matroid is None:
             L = LatticeOfFlats(A, poset=int_poset)
         else:
             L = LatticeOfFlats(matroid=matroid)
@@ -335,40 +341,40 @@ def CoarseFlagHPSeries(A=None, lattice_of_flats=None, int_poset=None, matroid=No
     if verbose:
         print("{0}Computing coarse flag Hilbert--Poincare series".format(_time()))
     cfHP = _comb_skele(L)
-    
+
     if numerator:
         D = cfHP.numerator_denominator()[1]
         T = D.variables()[0]
-        if D == (T - 1)**(L.poset.rank()): 
+        if D == (T - 1)**(L.poset.rank()):
             e = -1
-        if D == (1 - T)**(L.poset.rank()): 
+        if D == (1 - T)**(L.poset.rank()):
             e = 1
         return e*(cfHP*D).factor()
-    else: 
-        return cfHP 
+    else:
+        return cfHP
 
 
 def IgusaZetaFunction(X=None, lattice_of_flats=None, int_poset=None, matroid=None, verbose=_print):
     from .LatticeFlats import LatticeOfFlats
     from sage.all import var
 
-    HPA = True 
-    if matroid == None:
+    HPA = True
+    if matroid is None:
         try:
-            # Check if a hyperplane arrangement. 
+            # Check if a hyperplane arrangement.
             _ = X.hyperplanes()
             A = X
         except AttributeError:
-            # Not an HPA; deal with polynomial input. 
+            # Not an HPA; deal with polynomial input.
             A, M = _parse_poly(X)
             if verbose:
                 print("{0}Constructed a hyperplane arrangement".format(_time()))
-            HPA = False 
+            HPA = False
 
-    if lattice_of_flats == None:
+    if lattice_of_flats is None:
         if verbose:
             print("{0}Building lattice of flats".format(_time()))
-        if matroid == None:
+        if matroid is None:
             L = LatticeOfFlats(A, poset=int_poset)
         else:
             L = LatticeOfFlats(matroid=matroid)
@@ -385,7 +391,7 @@ def IgusaZetaFunction(X=None, lattice_of_flats=None, int_poset=None, matroid=Non
                 print("{0}Computing the atom zeta function".format(_time()))
             Z = _universal(L, anayltic=True, atom=True)
             t = var('t')
-            SUB = {var('t' + str(k+1)) : t**(M[k]) for k in range(len(M))}
+            SUB = {var('t' + str(k+1)): t**(M[k]) for k in range(len(M))}
             return Z.subs(SUB)
 
     if verbose:
@@ -397,25 +403,25 @@ def TopologicalZetaFunction(X=None, lattice_of_flats=None, int_poset=None, verbo
     from .LatticeFlats import LatticeOfFlats
     from sage.all import var
 
-    HPA = True 
-    if matroid == None:
+    HPA = True
+    if matroid is None:
         try:
-            # Check if a hyperplane arrangement. 
+            # Check if a hyperplane arrangement.
             _ = X.hyperplanes()
             A = X
         except AttributeError:
-            # Not an HPA; deal with polynomial input. 
+            # Not an HPA; deal with polynomial input.
             A, M = _parse_poly(X)
             if verbose:
                 print("{0}Constructed a hyperplane arrangement".format(_time()))
-            HPA = False 
+            HPA = False
 
-    if lattice_of_flats == None:
-        if matroid == None:
+    if lattice_of_flats is None:
+        if matroid is None:
             if verbose:
                 print("{0}Building lattice of flats".format(_time()))
             L = LatticeOfFlats(A, poset=int_poset)
-        else: 
+        else:
             L = LatticeOfFlats(matroid=matroid)
     else:
         L = lattice_of_flats
@@ -424,12 +430,12 @@ def TopologicalZetaFunction(X=None, lattice_of_flats=None, int_poset=None, verbo
         print("{0}Computing the topological zeta function".format(_time()))
 
     if not HPA:
-        if list(M) == [1]*len(M):
+        if list(M) == [1] * len(M):
             return _top_zeta_function_uni(L)
         else:
             Z = _top_zeta_function_mul(L, atom=True)
             s = var('s')
-            SUB = {var('s' + str(k+1)) : M[k]*s for k in range(len(M))}
+            SUB = {var('s' + str(k+1)): M[k]*s for k in range(len(M))}
             return Z.subs(SUB)
 
     if not multivariate:
@@ -441,12 +447,12 @@ def TopologicalZetaFunction(X=None, lattice_of_flats=None, int_poset=None, verbo
 def AnalyticZetaFunction(A=None, lattice_of_flats=None, int_poset=None, matroid=None, verbose=_print):
     from .LatticeFlats import LatticeOfFlats
 
-    if lattice_of_flats == None:
-        if matroid == None:
+    if lattice_of_flats is None:
+        if matroid is None:
             if verbose:
                 print("{0}Building lattice of flats".format(_time()))
             L = LatticeOfFlats(A, poset=int_poset)
-        else: 
+        else:
             L = LatticeOfFlats(matroid=matroid)
     else:
         L = lattice_of_flats
@@ -459,12 +465,12 @@ def AnalyticZetaFunction(A=None, lattice_of_flats=None, int_poset=None, matroid=
 def AtomZetaFunction(A=None, lattice_of_flats=None, int_poset=None, matroid=None, verbose=_print):
     from .LatticeFlats import LatticeOfFlats
 
-    if lattice_of_flats == None:
-        if matroid == None:
+    if lattice_of_flats is None:
+        if matroid is None:
             if verbose:
                 print("{0}Building lattice of flats".format(_time()))
             L = LatticeOfFlats(A, poset=int_poset)
-        else: 
+        else:
             L = LatticeOfFlats(matroid=matroid)
     else:
         L = lattice_of_flats
@@ -477,12 +483,12 @@ def AtomZetaFunction(A=None, lattice_of_flats=None, int_poset=None, matroid=None
 def FlagHilbertPoincareSeries(A=None, lattice_of_flats=None, int_poset=None, matroid=None, verbose=_print):
     from .LatticeFlats import LatticeOfFlats
 
-    if lattice_of_flats == None:
-        if matroid == None:
+    if lattice_of_flats is None:
+        if matroid is None:
             if verbose:
                 print("{0}Building lattice of flats".format(_time()))
             L = LatticeOfFlats(A, poset=int_poset)
-        else: 
+        else:
             L = LatticeOfFlats(matroid=matroid)
     else:
         L = lattice_of_flats

--- a/hypigu/src/LatticeFlats.py
+++ b/hypigu/src/LatticeFlats.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2020 Joshua Maglione 
+#   Copyright 2020 Joshua Maglione
 #
 #   Distributed under MIT License
 #
@@ -12,9 +12,9 @@ import sage.parallel.decorate as _para
 
 
 def _contract(M, rows):
-    from sage.all import Matrix, identity_matrix
+    from sage.all import Matrix
     K = M.base_ring()
-    Q = [M[k] for k in rows] + [M[k] for k in range(M.nrows()) if not k in rows]
+    Q = [M[k] for k in rows] + [M[k] for k in range(M.nrows()) if k not in rows]
     Q = Matrix(K, Q).transpose()
     top = Q[0]
     E = Q[1:, :].echelon_form()
@@ -26,9 +26,11 @@ def _contract(M, rows):
         v = E[r]
         i = list(v).index(1)
         top = top - top[i]*v
-    A = [tuple(list(top)[len(rows):])] + [out_E[k] for k in range(E.nrows()) if not k in rm]
+    A = [tuple(list(top)[len(rows):])] + [out_E[k] for k in range(E.nrows())
+                                          if k not in rm]
     M_out = Matrix(K, A).transpose()
     return M_out
+
 
 # BUILD A WAY TO GET THE LABELS FROM THE CONTRACT MATRIX
 def _get_labels(M, x, rows, L):
@@ -42,12 +44,12 @@ def _get_labels(M, x, rows, L):
     lines = []
     labels = []
     for r in range(M.nrows()):
-        v = M[r] 
-        is_new = not_e1(v) 
+        v = M[r]
+        is_new = not_e1(v)
         i = 0
         while i < len(lines) and is_new:
             if v in V.subspace([lines[i]]):
-                is_new = False 
+                is_new = False
                 labels[i] = labels[i].union(Set([r]))
             else:
                 i += 1
@@ -60,7 +62,7 @@ def _get_labels(M, x, rows, L):
     for k in rows:
         adjust = lambda i: i + (k <= i)*1
         labels = list(map(fix_sets(adjust), labels))
-    labels = [Set(rows)] + labels 
+    labels = [Set(rows)] + labels
 
     # Adjust the row labels to hyperplane labels
     HL = L.hyperplane_labels
@@ -84,41 +86,43 @@ def _get_labels(M, x, rows, L):
                 new_T = new_T.union(Set([new_hyp[k]]))
         return new_T
 
-    return Matrix(lines),last_adj,{new_hyp[i] : i for i in range(len(new_hyp))}
+    return Matrix(lines), last_adj, {new_hyp[i]: i for i in range(len(new_hyp))}
+
 
 def _parse_poset(P):
     global POS, atoms, labs, int_at
     from sage.all import Set
     import sage.parallel.decorate as para
-    
+
     POS = P
     N = _N
     atoms = POS.upper_covers(POS.bottom())
 
     @para.parallel(N)
-    def atom_set(k, shift): 
+    def atom_set(k, shift):
         S = list(POS._elements[1+shift::k])
         m = lambda x: [x, Set(list(filter(lambda a: POS.le(a, x), atoms)))]
         return list(map(m, S))
 
     labs = list(atom_set([(N, k) for k in range(N)]))
     labs = [[P.bottom(), Set([])]] + _reduce(lambda x, y: x + y[1], labs, [])
-    label_dict = {T[0] : T[1] for T in labs}
+    label_dict = {T[0]: T[1] for T in labs}
 
     return label_dict
+
 
 # Can return the subarrangement A_x or restriction A^x simply based on the
 # function F given. For subarrangement use 'lambda z: P.lower_covers(z)' and for
 # restriction use 'lambda z: P.upper_covers(z)'.
 def _subposet(P, x, F):
-    from sage.all import Set, Poset
+    from sage.all import Set
     elts = Set([])
     new_level = Set([x])
     while len(elts.union(new_level)) > len(elts):
         elts = elts.union(new_level)
         new_level = Set(_reduce(
-            lambda x, y: x+y, 
-            map(F, new_level), 
+            lambda x, y: x+y,
+            map(F, new_level),
             []
         ))
     new_P = P.subposet(elts)
@@ -126,7 +130,7 @@ def _subposet(P, x, F):
 
 
 # Parallel function to build the intersection lattice.
-# Moved to global to prevent accidentally carrying unnecessary data. 
+# Moved to global to prevent accidentally carrying unnecessary data.
 @_para.parallel(_N)
 def build_next(A, S, HYP, LIN):
     from sage.all import exists, Set
@@ -138,24 +142,24 @@ def build_next(A, S, HYP, LIN):
         T = LIN[i - m]
         for j in range(len(A)):
             # Skip the hyperplane already known to contain the intersection.
-            if not j in HYP[i - m]: 
+            if j not in HYP[i - m]:
                 H = A[j]
                 I = H._affine_subspace().intersection(T)
                 # Check if the intersection is trivial.
                 if I is not None:
-                    if I == T: 
+                    if I == T:
                         # This case means that H cap T = T, so we should
                         # record that H contains T.
                         HYP[i - m] = HYP[i - m].union(Set([j]))
                     else:
-                        # Check if we have this intersection already. 
+                        # Check if we have this intersection already.
                         is_in, ind = exists(
-                            range(len(new_level)), 
+                            range(len(new_level)),
                             lambda k: I == new_level[k]
                         )
                         if is_in:
                             # We have the intersection, so we update
-                            # containment info accordingly. 
+                            # containment info accordingly.
                             new_hypcont[ind] = new_hypcont[ind].union(
                                 Set([j]).union(HYP[i - m])
                             )
@@ -168,10 +172,10 @@ def build_next(A, S, HYP, LIN):
 
 # We expand on the function in sage, optimizing a little bit. This makes little
 # difference in small ranks but noticeable difference in larger ranks. This is
-# still quite slow. 
+# still quite slow.
 def _para_intersection_poset(A):
     from sage.geometry.hyperplane_arrangement.affine_subspace import AffineSubspace
-    from sage.all import exists, flatten, Set, QQ, VectorSpace, Poset
+    from sage.all import Set, VectorSpace, Poset
     from .Globals import __SANITY
 
     N = _N
@@ -180,17 +184,17 @@ def _para_intersection_poset(A):
     # L is the ranked list of affine subspaces in L(A).
     L = [[whole_space], list(map(lambda H: H._affine_subspace(), A))]
     # hyp_cont is the ranked list describing which hyperplanes contain the
-    # corresponding intersection. 
+    # corresponding intersection.
     hyp_cont = [[Set([])], [Set([k]) for k in range(len(A))]]
 
     c = A.is_central()*(-1)
     for r in range(2, A.rank() + c + 1):
         print("{1}Working on elements of rank {0}".format(r, _time()))
         m = len(L[r-1])
-        pmax = lambda k: (k+1)*(m//N) + (k==N-1)*(m%N)
+        pmax = lambda k: (k+1)*(m//N) + (k == N-1)*(m % N)
         pmin = lambda k: k*(m//N)
         all_input = lambda k: tuple([
-            A, range(pmin(k), pmax(k)), 
+            A, range(pmin(k), pmax(k)),
             hyp_cont[r - 1][pmin(k):pmax(k)], L[r - 1][pmin(k):pmax(k)]
         ])
         data = list(build_next(
@@ -248,7 +252,7 @@ def _para_intersection_poset(A):
         print("{0}Running sanity check".format(_time()))
         assert len(L_flat) == len(hc_flat)
         for i in range(len(hc_flat)):
-            for j in range(i+1, len(hc_flat)): 
+            for j in range(i+1, len(hc_flat)):
                 assert hc_flat[i] != hc_flat[j], "{0} vs {1}".format(i, j)
         for i in range(len(L_flat)):
             I = list(map(lambda x: A[x], hc_flat[i]))
@@ -260,29 +264,29 @@ def _para_intersection_poset(A):
     for i in range(len(hc_flat)):
         t[i] = Set(list(map(lambda x: x+1, hc_flat[i])))
     cmp_fn = lambda p, q: t[p].issubset(t[q])
-    label_dict = {i : t[i] for i in range(len(hc_flat))}
+    label_dict = {i: t[i] for i in range(len(hc_flat))}
     get_hyp = lambda i: A[label_dict[i].an_element() - 1]
-    hyp_dict = {i + 1 : get_hyp(i + 1) for i in range(len(A))}
+    hyp_dict = {i + 1: get_hyp(i + 1) for i in range(len(A))}
 
     return [Poset((t, cmp_fn)), label_dict, hyp_dict]
 
 
 # Default SageMath algorithm works well. However 'A.matroid()' seems to remove
-# ordering, which we depend on, so care is needed. 
+# ordering, which we depend on, so care is needed.
 def _lof_from_matroid(A=None, matroid=None):
     from sage.all import Set, Matrix, Matroid, Poset
     from functools import reduce
-    if A != None:
+    if A is not None:
         rows = list(map(lambda H: H.coefficients()[1:], A.hyperplanes()))
         mat = Matrix(A.base_ring(), rows).transpose()
         M = Matroid(mat)
         n = len(A)
-        lbl_map = lambda S: S 
+        lbl_map = lambda S: S
     else:
         M = matroid.simplify()
         n = len(M.groundset())
         grd_list = list(M.groundset())
-        l_map = {x : grd_list.index(x) for x in grd_list}
+        l_map = {x: grd_list.index(x) for x in grd_list}
         lbl_map = lambda S: frozenset([l_map[x] for x in S])
 
     L = M.lattice_of_flats()
@@ -291,78 +295,79 @@ def _lof_from_matroid(A=None, matroid=None):
     )
     rank_1 = [frozenset([k]) for k in range(n)]
     ranks = reduce(
-        lambda x, y: x + y, 
-        [rank_r(L, r) for r in range(2, L.rank() + 1)], 
+        lambda x, y: x + y,
+        [rank_r(L, r) for r in range(2, L.rank() + 1)],
         [L.bottom()] + rank_1
     )
     P = Poset(
-        L, element_labels={x : ranks.index(lbl_map(x)) for x in L._elements}
+        L, element_labels={x: ranks.index(lbl_map(x)) for x in L._elements}
     )
     adj_set = lambda S: Set([x+1 for x in S])
-    label_dict = {i : adj_set(ranks[i]) for i in range(len(L))}
-    if A != None:
-        hyp_dict = {i : A[list(ranks[i])[0]] for i in range(1, n + 1)}
-    else: 
-        hyp_dict = None 
+    label_dict = {i: adj_set(ranks[i]) for i in range(len(L))}
+    if A is not None:
+        hyp_dict = {i: A[list(ranks[i])[0]] for i in range(1, n + 1)}
+    else:
+        hyp_dict = None
     return [P, label_dict, hyp_dict]
 
 
 def _lof_from_affine_matroid(A):
-    from sage.all import Poset, Set 
+    from sage.all import Poset, Set
     from functools import reduce
     A_coned = A.cone()
     hyps = list(map(lambda H: H.coefficients(), A_coned.hyperplanes()))
     extra = [0, 1] + [0]*(A.dimension())
     i = hyps.index(extra)
     P, L, H = _lof_from_matroid(A_coned)
-    assert (H[i + 1]).coefficients() == extra 
+    assert (H[i + 1]).coefficients() == extra
     new_elts = list(filter(lambda x: not P.le(i + 1, x), P))
     new_elts = reduce(
         lambda x, y: x + y,
         [list(filter(lambda x: P.rank(x) == r, new_elts)) for r in range(2, P.rank() + 1)],
         [0] + [j for j in range(1, len(A_coned) + 1) if j != i + 1]
     )
-    new_names = {x : new_elts.index(x) for x in new_elts}
+    new_names = {x: new_elts.index(x) for x in new_elts}
     adj_set = lambda S: Set([new_names[x] for x in S if x in new_elts])
     P_new = Poset(P.subposet(new_elts), element_labels=new_names)
-    L_new = {new_names[x] : adj_set(L[x]) for x in new_elts}
-    def inv_H(h): 
+    L_new = {new_names[x]: adj_set(L[x]) for x in new_elts}
+
+    def inv_H(h):
         cut = lambda x: x.coefficients()[1:]
-        pair = list(filter(lambda x: cut(x[1]) == h, H.items())) 
+        pair = list(filter(lambda x: cut(x[1]) == h, H.items()))
         return pair[0][0]
-    H_new = {new_names[inv_H(h.coefficients())] : h for h in A}
+    H_new = {new_names[inv_H(h.coefficients())]: h for h in A}
     return [P_new, L_new, H_new]
 
 
 class LatticeOfFlats():
 
-    def __init__(self, A=None, poset=None, flat_labels=None, 
-    hyperplane_labels=None, lazy=False, matroid=None, 
+    def __init__(self, A=None, poset=None, flat_labels=None,
+    hyperplane_labels=None, lazy=False, matroid=None,
     nature_hyperplane_label=True):
         self.hyperplane_arrangement = A
-        self.poset = poset 
+        self.poset = poset
         self.flat_labels = flat_labels
         self.hyperplane_labels = hyperplane_labels
-        if poset != None:
+        if poset is not None:
             assert poset.has_bottom(), "Expected a unique minimal element in poset."
             assert poset.is_graded(), "Expected a graded poset."
             self.poset = poset
         else:
             if not lazy:
-                if A != None: 
+                if A is not None:
                     if A.is_central():
                         P, FL, HL = _lof_from_matroid(A)
                     else:
                         P, FL, HL = _lof_from_affine_matroid(A)
-                else: 
+                else:
                     P, FL, HL = _lof_from_matroid(A=None, matroid=matroid)
                 self.poset = P
                 self.flat_labels = FL
                 self.hyperplane_labels = HL
-        if self.flat_labels == None and not lazy:
+        if self.flat_labels is None and not lazy:
             self.flat_labels = _parse_poset(poset)
-        if self.hyperplane_arrangement != None and self.hyperplane_labels == None and nature_hyperplane_label:
-            self.hyperplane_labels = {i + 1 : A[i] for i in range(len(A))}
+        if self.hyperplane_arrangement is not None and self.hyperplane_labels is None and nature_hyperplane_label:
+            self.hyperplane_labels = {i + 1: A[i] for i in range(len(A))}
 
     def __repr__(self):
         if self.hyperplane_arrangement:
@@ -377,8 +382,8 @@ class LatticeOfFlats():
         CR = tuple(map(lambda T: tuple(T), self.poset.cover_relations()))
         FL = self.flat_labels
         FL_tup = tuple([tuple([x, list(FL[x])]) for x in FL.keys()])
-        del FL 
-        dict_builder = "FL = {x[0] : Set(x[1]) for x in FL_tup}\n"
+        del FL
+        dict_builder = "FL = {x[0]: Set(x[1]) for x in FL_tup}\n"
         with open(file, "w") as F:
             F.write("from sage.all import HyperplaneArrangements, QQ, Poset, Set\n")
             F.write("import hypigu as hi\n")
@@ -396,7 +401,6 @@ class LatticeOfFlats():
             F.write("del H, A, CR, P, FL\n")
             F.write("print('Loaded a lattice of flats. Variable name: {0}')".format(var_name))
 
-
     def atoms(self):
         return self.poset.upper_covers(self.poset.bottom())
 
@@ -405,7 +409,7 @@ class LatticeOfFlats():
         return list(map(elt_tup, self.poset._elements))
 
     def labels_of_hyperplanes(self):
-        P = self.poset 
+        P = self.poset
         elt_tup = lambda x: tuple([x, self.hyperplane_labels[x]])
         return list(map(elt_tup, P.upper_covers(P.bottom())))
 
@@ -421,70 +425,70 @@ class LatticeOfFlats():
         self.poset.show()
 
     def subarrangement(self, x):
-        P = self.poset 
+        P = self.poset
         if type(x) != set:
             assert x in P, "Expected element to be in poset."
             new_P = _subposet(P, x, lambda z: P.lower_covers(z))
-            new_A = None 
+            new_A = None
             new_FL = None
-            new_HL = None 
+            new_HL = None
             if self.hyperplane_arrangement and self.hyperplane_labels:
                 A = self.hyperplane_arrangement
                 HL = self.hyperplane_labels
                 atoms = new_P.upper_covers(new_P.bottom())
                 keep = list(map(lambda k: HL[k], atoms))
                 new_A = A.parent()(keep)
-                new_HL = {a : HL[a] for a in atoms}
+                new_HL = {a: HL[a] for a in atoms}
             if self.flat_labels:
                 FL = self.flat_labels
-                new_FL = {x : FL[x] for x in new_P._elements}
+                new_FL = {x: FL[x] for x in new_P._elements}
             return LatticeOfFlats(new_A, poset=new_P, flat_labels=new_FL, hyperplane_labels=new_HL)
         else:
-            L = self.flat_labels 
+            L = self.flat_labels
             X = list(filter(lambda y: L[y] == x, P._elements))
             try:
                 return self.subarrangement(X[0])
             except IndexError:
                 raise ValueError("No element labeled by:\n{0}".format(x))
-    
+
     def restriction(self, x):
         from sage.all import Matrix, HyperplaneArrangements
-        P = self.poset 
+        P = self.poset
         if type(x) != set:
             assert x in P, "Expected element to be in poset."
             new_P = _subposet(P, x, lambda z: P.upper_covers(z))
-            new_A = None 
-            new_HL = None 
+            new_A = None
+            new_HL = None
             if self.hyperplane_arrangement:
                 A = self.hyperplane_arrangement
                 hyp_coeffs = map(lambda H: H.coefficients(), A.hyperplanes())
                 M = Matrix(A.base_ring(), list(hyp_coeffs))
                 rows = sorted(list(map(
-                    lambda H: list(A).index(self.hyperplane_labels[H]), 
+                    lambda H: list(A).index(self.hyperplane_labels[H]),
                     self.flat_labels[x]
                 )))
                 new_M = _contract(M, rows)
                 new_M, lab_func, hyp_dict = _get_labels(new_M, x, rows, self)
                 HH = HyperplaneArrangements(
-                    A.base_ring(), 
+                    A.base_ring(),
                     A.parent().variable_names()[:new_M.ncols()-1]
                 )
                 new_A = HH(new_M)
                 FL = self.flat_labels
-                new_FL = {x : lab_func(FL[x]) for x in new_P._elements}
-                new_HL = {a : new_A[hyp_dict[a]] for a in new_P.upper_covers(new_P.bottom())}
+                new_FL = {x: lab_func(FL[x]) for x in new_P._elements}
+                new_HL = {a: new_A[hyp_dict[a]] for a in new_P.upper_covers(new_P.bottom())}
             else:
                 FL = self.flat_labels
-                new_FL = {y : FL[y].difference(FL[x]) for y in new_P._elements}
+                new_FL = {y: FL[y].difference(FL[x]) for y in new_P._elements}
             return LatticeOfFlats(new_A, poset=new_P, flat_labels=new_FL, hyperplane_labels=new_HL)
         else:
-            L = self.flat_labels 
+            L = self.flat_labels
             X = list(filter(lambda y: L[y] == x, P._elements))
             try:
                 return self.restriction(X[0])
             except IndexError:
                 raise ValueError("No element labeled by:\n{0}".format(x))
-    
+
     def deletion(self, H):
         from sage.all import Set
 
@@ -492,13 +496,13 @@ class LatticeOfFlats():
         L = self.flat_labels
 
         if type(H) == set:
-            L = self.flat_labels 
+            L = self.flat_labels
             X = list(filter(lambda y: L[y] == H, P._elements))
             try:
                 return self.deletion(X[0])
             except IndexError:
                 raise ValueError("No element labeled by:\n{0}".format(H))
-            
+
         assert P.rank_function()(H) == 1, "Expected an atom."
 
         if P.has_top():
@@ -508,25 +512,26 @@ class LatticeOfFlats():
             coatoms = P.maximal_elements()
 
         m = len(self.atoms()) - 1
+
         def check(C):
             S = L[C]
-            return bool(len(S) == m and not H in S)
+            return bool(len(S) == m and H not in S)
         new_top = list(filter(check, coatoms))
 
         if len(new_top) == 1:
             new_P = _subposet(P, new_top[0], lambda z: P.lower_covers(z))
-            new_FL = {y : L[y] for y in new_P._elements}
+            new_FL = {y: L[y] for y in new_P._elements}
         else:
             def good_flats(F):
                 S = L[F]
                 if H in S:
                     U = S.difference(Set([H]))
-                    return (U != 0) and (not U in L.values())
+                    return (U != 0) and (U not in L.values())
                 else:
                     return True
             flats = list(filter(good_flats, P._elements))
             new_P = P.subposet(flats)
-            new_FL = {y : L[y].difference(Set([H])) for y in flats}
+            new_FL = {y: L[y].difference(Set([H])) for y in flats}
 
         if self.hyperplane_arrangement:
             HPA = self.hyperplane_arrangement
@@ -534,7 +539,7 @@ class LatticeOfFlats():
             A = list(HPA)
             A.remove(HPA[H])
             new_HPA = HPA.parent()(A)
-            new_HL = {x : HL[x] for x in new_P.upper_covers(new_P.bottom())}
+            new_HL = {x: HL[x] for x in new_P.upper_covers(new_P.bottom())}
         else:
             new_HPA = None
             new_HL = None
@@ -543,13 +548,13 @@ class LatticeOfFlats():
 
     def _lazy_restriction(self, H):
         HPA = self.hyperplane_arrangement
-        assert HPA != None, "Needs underlying hyperplane arrangement."
+        assert HPA is not None, "Needs underlying hyperplane arrangement."
         A = HPA.restriction(HPA[H - 1])
         return LatticeOfFlats(A, lazy=True)
 
     def _lazy_deletion(self, H):
         HPA = self.hyperplane_arrangement
-        assert HPA != None, "Needs underlying hyperplane arrangement."
+        assert HPA is not None, "Needs underlying hyperplane arrangement."
         return LatticeOfFlats(HPA.parent()(HPA[:H-1] + HPA[H:]), lazy=True)
 
     @cached_method
@@ -557,34 +562,33 @@ class LatticeOfFlats():
         from sage.all import QQ, PolynomialRing
         PR = PolynomialRing(QQ, 'Y')
         Y = PR.gens()[0]
-        if self.poset != None:
-            P = self.poset 
+        if self.poset is not None:
+            P = self.poset
             atoms = self.atoms()
             if P.rank() == 0:
                 return PR(1)
             if P.rank() == 1:
                 return PR(1 + len(atoms)*Y)
-        else: 
-            # Lazy 
+        else:
+            # Lazy
             A = self.hyperplane_arrangement
-            assert A != None, "Expected either a poset or hyperplane arrangement."
+            assert A is not None, "Expected either a poset or hyperplane arrangement."
             if A.rank() == 0:
                 return PR(1)
             if A.rank() == 1:
                 return PR(1 + len(A)*Y)
-        if self.hyperplane_arrangement != None:
-            try: # Some hyperplane arrangements are bugged in SageMath.
+        if self.hyperplane_arrangement is not None:
+            try:  # Some hyperplane arrangements are bugged in SageMath.
                 D = self._lazy_deletion(1)
                 R = self._lazy_restriction(1)
                 return PR(D.Poincare_polynomial() + Y*R.Poincare_polynomial())
-            except: 
-                pass 
+            except Exception:
+                pass
         chi = self.poset.characteristic_polynomial()
         q = chi.variables()[0]
         d = chi.degree(q)
-        return PR((-Y)**d*chi.subs({q : -Y**-1}))
-        
-        
+        return PR((-Y)**d*chi.subs({q: -Y**-1}))
+
     @cached_method
     def _combinatorial_eq_elts(self):
         global POS, P_elts
@@ -626,7 +630,7 @@ class LatticeOfFlats():
         prelim_elts = list(match_elts([(N, k) for k in range(N)]))
         prelim_elts = _reduce(lambda x, y: x + y[1], prelim_elts, [])
 
-        # Test further to minimize the size. 
+        # Test further to minimize the size.
         equiv_elts = []
         while len(prelim_elts) > 0:
             x = prelim_elts[0]
@@ -656,15 +660,16 @@ def _Coxeter_poset_data():
                 lambda x, y: x + y[0]*binomial(m, y[1]), zip(S, range(m+1)), 0
             ))
         return S[n+1]
+
     def S(n, k, m):
-        if k > n or k < 0 : 
+        if k > n or k < 0:
             return 0
-        if n == 0 and k == 0: 
+        if n == 0 and k == 0:
             return 1
         return S(n-1, k-1, m) + (m*(k+1)-1)*S(n-1, k, m)
-    def A007405(n): 
-        from sage.all import add
-        return add(S(n, k, 2) for k in (0..n)) # Peter Luschny, May 20 2013
+
+    def A007405(n):
+        return sum(S(n, k, 2) for k in range(n + 1))  # Peter Luschny, May 20 2013
     # D analog of Bell numbers: A039764
     Dlist = [1, 1, 4, 15, 72, 403, 2546, 17867, 137528, 1149079, 10335766, 99425087, 1017259964, 11018905667, 125860969266, 1510764243699, 18999827156304, 249687992188015, 3420706820299374, 48751337014396167]
     table = {
@@ -683,9 +688,10 @@ def _Coxeter_poset_data():
     }
     return table
 
+
 def _possibly_Coxeter(P):
     r = P.rank()
-    hypers = list(filter(lambda x: P.covers(P.bottom(), x), P))
+    hypers = [x for x in P if P.covers(P.bottom(), x)]
     m = len(hypers)
     CPD = _Coxeter_poset_data()
     for name in ['A', 'B', 'D']:


### PR DESCRIPTION
some changes about 

- comparison to None
- no space before colon
- other pep8 style recommandations
- no trailing whitespaces
- using `x not in E`

some of them were found using `sage --tox -e pycodestyle-minimal .`
